### PR TITLE
fix getting dbtable from magento env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Fix getting dbtable from Magento's env.php
 
 ## [Released]
 ## [1.0.0] - 26.05.2022

--- a/src/database-actions.js
+++ b/src/database-actions.js
@@ -18,7 +18,7 @@ function getValue(table, name) {
 // EXTRACTING DATABASE CREDENTIALS FROM ETC/ENV FILE IN PHP FORMAT
 async function getDatabaseDetails() {
   const file = await readFile((envPhpPath))
-  const dbTable = file.toString().split('[').filter((x) => x.includes('host'))
+  const dbTable = file.toString().split('[').filter((x) => x.includes('dbname'))
   const host = getValue(dbTable, 'host')
   const database = getValue(dbTable, 'dbname')
   const user = getValue(dbTable, 'username')


### PR DESCRIPTION
### Description

https://github.com/SnowdogApps/create-alpaca-theme/blob/dfc0e6af81edac01e161ab0243f5c7caf68ead6a/src/database-actions.js#L21

When creating a new theme using `npx @snowdog/create-alpaca-theme` command on a new [warden](https://docs.warden.dev/environments/magento2.html) magento2 install the above line doesn't parse the etc/env.php db table correctly. Probable cause is that it filters array item based on the first `host` occurence in the array tree. In case of warden install, first occurence would be queue array(finding IP of `rabbitmq` matches the IP this script tried to connect to.

<details>
<summary>
app/etc/env.php snippet
</summary>

```
...
'queue' => [
        'amqp' => [
            'host' => 'rabbitmq',
            'port' => '5672',
            'user' => 'guest',
            'password' => 'guest',
            'virtualhost' => '/'
        ],
        'consumers_wait_for_messages' => 1
    ],
...
'db' => [
        'table_prefix' => '',
        'connection' => [
            'default' => [
                'host' => 'db',
                'dbname' => 'magento',
                'username' => 'magento',
                'password' => 'magento',
                'model' => 'mysql4',
                'engine' => 'innodb',
                'initStatements' => 'SET NAMES utf8;',
                'active' => '1',
                'driver_options' => [
                    1014 => false
                ]
            ]
        ]
    ],
...
```

</details>

### Solution
Below change seemed to work locally and command was able to finish but maybe there's some better way for getting the needed db info
` const dbTable = file.toString().split('[').filter((x) => x.includes('host')) `
to
` const dbTable = file.toString().split('[').filter((x) => x.includes('dbname')) `